### PR TITLE
Adds ignore location flag to fuse.js options

### DIFF
--- a/source/js/addons.js
+++ b/source/js/addons.js
@@ -219,7 +219,7 @@ function search(pattern) {
         threshold: 0.1,
         // distance: 100,
         // useExtendedSearch: false,
-        // ignoreLocation: false,
+        ignoreLocation: true,
         // ignoreFieldNorm: false,
         keys: [
             "addonId",


### PR DESCRIPTION
https://fusejs.io/api/options.html#ignorelocation
> When true, search will ignore location and distance, so it won't matter where in the string the pattern appears.

Allows to look throw the whole name and description of the add-on.

Fixes:
> I'm trying search on add-on browser and it looks like it only matches start of add-on's name. For example try searching for Installation Status Updater using status or updater terms, it won't find anything. Only using installation will find it. 
